### PR TITLE
client.end(flush) now with Flush

### DIFF
--- a/index.js
+++ b/index.js
@@ -422,11 +422,12 @@ RedisCluster.prototype.waitForTopology = function waitForTopology(){
 		}
 	}
 };
-RedisCluster.prototype.end = function end() {
+RedisCluster.prototype.end = function end(flush) {
+	flush=flush !== true;
 	this.connected = false;
 	this.topology.slots = {};
 	for(var k in this.cacheLinks) {
-		this.cacheLinks[k].end();
+		this.cacheLinks[k].end(flush);
 	}
 	this.cacheLinks = {};
 	this.topology.nodes = {};


### PR DESCRIPTION
Per NodeRedis documnetation

client.end(flush)
Forcibly close the connection to the Redis server. Note that this does not wait until all replies have been parsed. If you want to exit cleanly, call client.quit() as mentioned above.

You should set flush to true, if you are not absolutely sure you do not care about any other commands. If you set flush to false all still running commands will silently fail.

Signed-off-by: Ben Smith <ben.smith@infotechinc.com>